### PR TITLE
Issue16 - Change Font Color and improve UI of display photo section

### DIFF
--- a/backend/src/photoImposer.py
+++ b/backend/src/photoImposer.py
@@ -37,7 +37,7 @@ class photoImposer:
             message = ''
             for index, player in positional_group.iterrows():
                 message = message + str(player["PLAYER"]) + " " + str(player["COUNT"]) + " " + str(player["RATING"]) + '\n'
-            color = 'rgb(0, 0, 0)'
+            color = (237, 245, 7)
             draw.text((x, y), message, fill=color, font=font)
         
         imagename = './' + downloadPath + '/' + playType + '_ANALYSIS.png'

--- a/backend/src/photoImposer.py
+++ b/backend/src/photoImposer.py
@@ -37,6 +37,8 @@ class photoImposer:
             message = ''
             for index, player in positional_group.iterrows():
                 message = message + str(player["PLAYER"]) + " " + str(player["COUNT"]) + " " + str(player["RATING"]) + '\n'
+            
+            # setting font color to yellow instead of black for better contrast
             color = (237, 245, 7)
             draw.text((x, y), message, fill=color, font=font)
         

--- a/vue-app/src/components/DisplayPhotos.vue
+++ b/vue-app/src/components/DisplayPhotos.vue
@@ -6,7 +6,9 @@
                 <b-col cols="8">
                     <div v-b-scrollspy:scrollspy-nested >
                         <div>
-                            <b-card-img left :src="selectedImg.link" class="selected-img"></b-card-img>
+							<b-link :href="selectedImg.link" target="_blank">
+								<b-card-img left :src="selectedImg.link" class="selected-img"></b-card-img>
+							</b-link>
                         </div>
                     </div>
                 </b-col>
@@ -87,6 +89,6 @@ export default {
 .card {
     width: 100%;
     height: 100%;
-
+	margin-bottom: 80px;
 }
 </style>

--- a/vue-app/src/components/DisplayPhotos.vue
+++ b/vue-app/src/components/DisplayPhotos.vue
@@ -6,6 +6,8 @@
                 <b-col cols="8">
                     <div v-b-scrollspy:scrollspy-nested >
                         <div>
+							<!-- Wrapping image with hyperlink so that user can easily open the full screen image in new tab -->
+							<!-- It will be especially beneficial when the selected image does not fit properly in display section -->
 							<b-link :href="selectedImg.link" target="_blank">
 								<b-card-img left :src="selectedImg.link" class="selected-img"></b-card-img>
 							</b-link>
@@ -89,6 +91,6 @@ export default {
 .card {
     width: 100%;
     height: 100%;
-	margin-bottom: 80px;
+	margin-bottom: 80px; /* This is added to resolve the overlap issue of footer with display image card */
 }
 </style>


### PR DESCRIPTION
This pull request will close the [issue 16](https://github.com/pranav2595/American-Football-Analytics-Application/issues/16). 

1. Changed Font Color of the label so that we can see label clearly. The Background Color and Player size cannot be edited as it is fixed in the formation images.
2. Fixed the overlap issue of footer that previously clipped the bottom portion of the selected image in the display section.
3. Also, because dimensions of different formation images are different, some of the images were not being displayed properly in the display section. Thus, added hyperlink to the selected image which on click will open in new tab as full screen.